### PR TITLE
Automatically re-init after drifting, and handle local timezone

### DIFF
--- a/jltcgen.1
+++ b/jltcgen.1
@@ -21,8 +21,14 @@ display this help and exit
 \fB\-g\fR, \fB\-\-volume\fR float
 set output level in dBFS default \fB\-18db\fR
 .TP
+\fB\-l\fR, \fB\-\-localtime\fR
+automatically generated timecode in the currently configured timezone, instead of UTC
+.TP
 \fB\-m\fR, \fB\-\-timezone\fR tz
 set timezone in minutes\-west of UTC
+.TP
+\fB\-r\fR, \fB\-\-auto-resync\fR
+automatically re\-sync and re\-start the feed if it gets more than 100ms out of sync with the local clock. a check is performed once every 30 seconds.
 .TP
 \fB\-t\fR, \fB\-\-timecode\fR time
 specify start\-time/timecode [[[HH:]MM:]SS:]FF

--- a/ltcgen.c
+++ b/ltcgen.c
@@ -314,7 +314,7 @@ int main (int argc, char **argv) {
     struct tm gm;
     long int sync_date = 0;
     if (gmtime_r(&now, &gm))
-      sync_date = gm.tm_mday*10000 + gm.tm_mon*100 + gm.tm_year;
+      sync_date = gm.tm_mday*10000 + (gm.tm_mon + 1)*100 + (gm.tm_year % 100);
     sync_msec += 1000.0 * ltc_frame_alignment(samplerate * fps_den / (double) fps_num, ltc_tv) / samplerate;
     set_encoder_time(1000.0*sync_msec, sync_date, 0, fps_num, fps_den, 1);
   }


### PR DESCRIPTION
This adds 2 options:

auto_resync - automatically re-init timecode when outputting the current time

localtime - if outputting the current time, output it from the current timezeone, not UTC