### PR TITLE
Bug 17: 'Received' timestamp from within 'process()' and use 'off_start' for each packet.

### DIFF
--- a/jltcntp.c
+++ b/jltcntp.c
@@ -106,8 +106,11 @@ int process(jack_nframes_t nframes, void *arg)
     {
         n_usecs = jack_get_time();
         if (n_usecs < c_usecs)
-	     // rollover
+	{
+	     // rollover detected
 	     n_usecs -= 1000000;
+	     c_usecs -= 1000000;
+	}
         tv.tv_usec -= (n_usecs - c_usecs);
     }
 

--- a/jltcntp.c
+++ b/jltcntp.c
@@ -93,9 +93,14 @@ static volatile struct shmTime *shm = NULL;
  */
 int process(jack_nframes_t nframes, void *arg)
 {
+    struct timeval tv;
+    ltc_off_t posinfo;
+
+    gettimeofday(&tv, NULL);
     jack_default_audio_sample_t *in = jack_port_get_buffer(input_port, nframes);
 
-    ltc_decoder_write_float(decoder, in, nframes, 0);
+    posinfo = (tv.tv_sec * j_samplerate) + (tv.tv_usec * j_samplerate / 1000000) - nframes;
+    ltc_decoder_write_float(decoder, in, nframes, posinfo);
 
     /* notify reader thread */
     if (pthread_mutex_trylock(&ltc_thread_lock) == 0)
@@ -258,7 +263,11 @@ static void my_decoder_read(LTCDecoder *d)
             if (!shm->valid)
             {
                 struct timeval tv;
-                gettimeofday(&tv, NULL);
+                ltc_off_t delta;
+
+                tv.tv_sec = frame.off_start / j_samplerate;
+                delta = frame.off_start - (tv.tv_sec * j_samplerate);
+                tv.tv_usec = (1000000 * delta) / j_samplerate;
 
                 shm->clockTimeStampSec = time.tv_sec - offset;
                 shm->clockTimeStampUSec = time.tv_usec;

--- a/jltcntp.c
+++ b/jltcntp.c
@@ -96,7 +96,21 @@ int process(jack_nframes_t nframes, void *arg)
     struct timeval tv;
     ltc_off_t posinfo;
 
+    jack_nframes_t c_frames;
+    jack_time_t c_usecs;
+    jack_time_t n_usecs;
+    float p_usecs;
+
     gettimeofday(&tv, NULL);
+    if (jack_get_cycle_times(j_client, &c_frames, &c_usecs, &n_usecs, &p_usecs) == 0)
+    {
+        n_usecs = jack_get_time();
+        if (n_usecs < c_usecs)
+	     // rollover
+	     n_usecs -= 1000000;
+        tv.tv_usec -= (n_usecs - c_usecs);
+    }
+
     jack_default_audio_sample_t *in = jack_port_get_buffer(input_port, nframes);
 
     posinfo = (tv.tv_sec * j_samplerate) + (tv.tv_usec * j_samplerate / 1000000) - nframes;

--- a/jltcntp.c
+++ b/jltcntp.c
@@ -46,6 +46,7 @@
 #include <sys/shm.h>
 #include <sys/time.h>
 #include <time.h>
+#include <errno.h>
 
 static int keep_running = 1;
 
@@ -425,7 +426,17 @@ int main(int argc, char **argv)
 
     if (unit >= 0)
     {
-        int shmid = shmget(0x4e545030 + unit, sizeof (struct shmTime), IPC_CREAT | 0777);
+        int shmid = -1;
+        int errshm = EACCES;
+        const int perms[] = {0777, 0666, 0770, 0660, 0700, 0600};
+        int attempt = 0;
+
+        while (shmid == -1 && errshm == EACCES && attempt < sizeof(perms)) {
+            shmid = shmget(0x4e545030 + unit, sizeof (struct shmTime), IPC_CREAT | perms[attempt]);
+            errshm = errno;
+            attempt++;
+        }
+
         if (shmid != -1)
         {
             shm = (struct shmTime *) shmat(shmid, NULL, 0);


### PR DESCRIPTION
Bug #17 
Improves the accuracy of the 'Received' timestamps when using SHM to NTP/Chrony.