### PR TITLE
Improve accuracy for jltcntp

### DIFF
--- a/jltcntp.c
+++ b/jltcntp.c
@@ -66,6 +66,8 @@ static int no_date = 0;
 
 static int verbose = 0;
 
+static struct timeval tv_recv;
+
 struct shmTime
 {
     int             mode; /* 0 - if valid is set: use values, clear valid
@@ -93,6 +95,7 @@ static volatile struct shmTime *shm = NULL;
  */
 int process(jack_nframes_t nframes, void *arg)
 {
+    gettimeofday(&tv_recv, NULL);
     jack_default_audio_sample_t *in = jack_port_get_buffer(input_port, nframes);
 
     ltc_decoder_write_float(decoder, in, nframes, 0);
@@ -247,9 +250,6 @@ static void my_decoder_read(LTCDecoder *d)
             shm->mode = 0;
             if (!shm->valid)
             {
-                struct timeval tv_recv;
-                gettimeofday(&tv_recv, NULL);
-
                 shm->clockTimeStampSec = tv_clock.tv_sec - offset;
                 shm->clockTimeStampUSec = tv_clock.tv_usec;
                 shm->receiveTimeStampSec = tv_recv.tv_sec;

--- a/jltcntp.c
+++ b/jltcntp.c
@@ -60,7 +60,6 @@ static pthread_cond_t data_ready = PTHREAD_COND_INITIALIZER;
 
 static int fps_num = 25;
 static int fps_den = 1;
-static int max_frame = 25;
 
 static int unit = -1;
 static int no_date = 0;
@@ -219,16 +218,16 @@ static void my_decoder_read(LTCDecoder *d)
             {
                 offset = atoi(stime.timezone);
                 offset = (offset / 100) * 60 + (offset % 100);
-                offset *= 60; // seconds West of UTC
+                offset*= 60; // seconds West of UTC
 
                 tzset();
                 offset -= timezone; // offset between LTC and local timezone
             }
 
-            tm.tm_mday = stime.days;        // 1..31
-            tm.tm_mon = stime.months - 1;   // 0..11
-            tm.tm_year = stime.years + 100; // years since 1900
-            tm.tm_isdst = -1;               // look up DST
+            tm.tm_mday  = stime.days;        // 1..31
+            tm.tm_mon   = stime.months - 1;  // 0..11
+            tm.tm_year  = stime.years + 100; // years since 1900
+            tm.tm_isdst = -1;                // look up DST
         }
         else
         {
@@ -236,21 +235,13 @@ static void my_decoder_read(LTCDecoder *d)
             localtime_r(&tc, &tm);
         }
 
-        int missing = frame.ltc.dfbit * ((stime.mins % 10 * 2) + ((stime.mins / 10) * 18));
-        int actual = (((stime.mins * 60) + stime.secs) * max_frame) + stime.frame - missing;
-        long long int usec = (long long int) actual * 1000000 * fps_den / fps_num;
-
+        tm.tm_sec  = stime.secs;
+        tm.tm_min  = stime.mins;
         tm.tm_hour = stime.hours;
-        tm.tm_min = actual / (60 * max_frame);
-        usec -= (long long int) tm.tm_min * 60000000;
-
-        tm.tm_sec = ((actual - tm.tm_min * 60 * max_frame) / max_frame);
-        tm.tm_sec += (usec/1000000) - tm.tm_sec;
-        usec -= (long long int) tm.tm_sec *  1000000;
 
         struct timeval time;
         time.tv_sec = mktime(&tm);
-        time.tv_usec = usec;
+        time.tv_usec = 0;
 
         int sent = 0;
         if (shm && time.tv_sec != -1 && time.tv_sec != prev)
@@ -288,9 +279,6 @@ static void my_decoder_read(LTCDecoder *d)
                 frame.ltc.dfbit ? '.' : ':',
                 stime.frame
             );
-
-            if (frame.ltc.dfbit)
-                printf(" (ahead %d -> xx:%2.2d:%2.2d & %ldus)", missing, tm.tm_min, tm.tm_sec, time.tv_usec);
 
             if (sent)
                 printf(" ==> %s", asctime(&tm));
@@ -381,8 +369,6 @@ static int decode_switches(int argc, char **argv)
                 fps_num = atoi(optarg);
                 char *tmp = strchr(optarg, '/');
                 if (tmp) fps_den = atoi(++tmp);
-
-                max_frame = (0.5 + (float)fps_num/fps_den);
             }
             break;
 


### PR DESCRIPTION
This PR reverts "Bug 19: Implement DropFrame processing (specifically for 29.97DF streams)", which does not seem to behave correctly. See my comment [here](https://github.com/x42/ltc-tools/pull/21#issuecomment-748556342).

It also adds several accuracy improvements suggested by @mungewell.