### PR TITLE
Stop using deprecated libltc API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ CFLAGS ?= -Wall -g -O2
 
 VERSION=0.7.0
 
-ifeq ($(shell pkg-config --atleast-version=1.1.0 ltc || echo no), no)
-  $(error "https://github.com/x42/libltc version >= 1.1.0 is required - install libltc-dev")
+ifeq ($(shell pkg-config --atleast-version=1.3.2 ltc || echo no), no)
+  $(error "https://github.com/x42/libltc version >= 1.3.2 is required - install libltc-dev")
 endif
 ifeq ($(shell pkg-config --exists jack || echo no), no)
   $(warning "http://jackaudio.org is recommended - install libjack-dev or libjack-jackd2-dev")

--- a/jltcgen.c
+++ b/jltcgen.c
@@ -347,7 +347,7 @@ void main_loop(void) {
       for (byteCnt = 0; byteCnt < 10; byteCnt++) {
 	int i;
 	ltc_encoder_encode_byte(encoder, byteCnt, 1.0);
-	const int len = ltc_encoder_get_buffer(encoder, enc_buf);
+	const int len = ltc_encoder_copy_buffer(encoder, enc_buf);
 	for (i=0;i<len;i++) {
 	  const float v1 = enc_buf[i] - 128;
 	  jack_default_audio_sample_t val = (jack_default_audio_sample_t) (v1*smult);

--- a/ltcgen.c
+++ b/ltcgen.c
@@ -68,7 +68,7 @@ void main_loop_reverse(void) {
       for (byteCnt = 9; byteCnt >= 0; byteCnt--) {
 	int i;
 	ltc_encoder_encode_byte(encoder, byteCnt, -1.0);
-	const int len = ltc_encoder_get_buffer(encoder, enc_buf);
+	const int len = ltc_encoder_copy_buffer(encoder, enc_buf);
 	if (!snd) snd = malloc(len * sizeof(short));
 	for (i=0;i<len;i++) {
 	  const short val = ( (int)(enc_buf[i] - 128) * smult / 90 );
@@ -101,7 +101,7 @@ void main_loop(void) {
       for (byteCnt = 0; byteCnt < 10; byteCnt++) {
 	int i;
 	ltc_encoder_encode_byte(encoder, byteCnt, 1.0);
-	const int len = ltc_encoder_get_buffer(encoder, enc_buf);
+	const int len = ltc_encoder_copy_buffer(encoder, enc_buf);
 	if (!snd) snd = malloc(len * sizeof(short));
 	for (i=0;i<len;i++) {
 	  const short val = ( (int)(enc_buf[i] - 128) * smult / 90 );


### PR DESCRIPTION
This makes us depend on libltc >= v1.3.2, which was released ~4 years ago.